### PR TITLE
tests: wait messages be deleted

### DIFF
--- a/test/integration/queue/aws/lambda/handler.js
+++ b/test/integration/queue/aws/lambda/handler.js
@@ -77,6 +77,10 @@ describe('LambdaHandler', () => {
       await new LambdaHandler(arnToQueueInfo, handlerFactories)
         .handle(lambdaInput).catch(() => { });
 
+      /*
+        this sleep is necessary because testing with localstack sometimes the queue still
+        has some messages that are in process of being deleted.
+      */
       await new Promise(resolve => setTimeout(resolve, 500));
 
       assert.equal(await queue.length(), failedMessages);

--- a/test/integration/queue/aws/lambda/handler.js
+++ b/test/integration/queue/aws/lambda/handler.js
@@ -50,11 +50,12 @@ describe('LambdaHandler', () => {
   });
 
   describe('with only some commands successfully executed', () => {
-    it('removes only failed messages from the queue', async () => {
+    it('removes only successful messages from the queue', async () => {
       const messageCount = faker.random.number({ max: 8, min: 3 });
       const failedMessages = messageCount - 2;
       const successMessages = messageCount - failedMessages;
 
+      assert.equal(await queue.length(), 0);
       await queue.sendManyRepeatedly(failedMessages, 'fail');
       await queue.sendManyRepeatedly(successMessages, 'success');
       assert.equal(await queue.length(), messageCount);
@@ -75,6 +76,9 @@ describe('LambdaHandler', () => {
 
       await new LambdaHandler(arnToQueueInfo, handlerFactories)
         .handle(lambdaInput).catch(() => { });
+
+      await new Promise(resolve => setTimeout(resolve, 500));
+
       assert.equal(await queue.length(), failedMessages);
     });
   });


### PR DESCRIPTION
We tested the same test with AWS SQS and it worked more than 100 times.
But when we use localstack it fails intermittently.

After some tests the solution found was add a 500 milliseconds sleep,
before check the queue length.